### PR TITLE
Update FlexSearch Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dist/searchinghost.min.js.map"
   ],
   "dependencies": {
-    "flexsearch": "^0.6.32"
+    "flexsearch": "^0.7.21"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",


### PR DESCRIPTION
This is a critical upgrade, mostly due to [this issue](https://github.com/nextapps-de/flexsearch/issues/70). With the default configuration, if a Ghost post title includes the search query, then only those posts with the search query in the title will be returned, even if other posts have the query in other fields like `string_tags`.